### PR TITLE
Update Docusaurus configuration for Mani.dev

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,35 +3,27 @@
 // (when paired with `@ts-check`).
 // There are various equivalent ways to declare your Docusaurus config.
 // See: https://docusaurus.io/docs/api/docusaurus-config
-
 import { themes as prismThemes } from "prism-react-renderer";
-
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "My Site",
-  tagline: "Dinosaurs are cool",
+  title: "Mani.dev",
+  tagline: "Software Engineering Knowledge Base",
   favicon: "img/favicon.ico",
-
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
-
   // Set the production url of your site here
   url: "https://maniarasan.github.io/",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/mani.dev/",
-
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "facebook", // Usually your GitHub org/user name.
-  projectName: "docusaurus", // Usually your repo name.
-
+  organizationName: "Maniarasan", // Usually your GitHub org/user name.
+  projectName: "mani.dev", // Usually your repo name.
   onBrokenLinks: "throw",
-
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
@@ -39,7 +31,6 @@ const config = {
     defaultLocale: "en",
     locales: ["en"],
   },
-
   presets: [
     [
       "classic",
@@ -50,7 +41,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/Maniarasan/mani.dev/tree/main/",
         },
         blog: {
           showReadingTime: true,
@@ -61,7 +52,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/Maniarasan/mani.dev/tree/main/",
           // Useful options to enforce blogging best practices
           onInlineTags: "warn",
           onInlineAuthors: "warn",
@@ -73,7 +64,6 @@ const config = {
       }),
     ],
   ],
-
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -83,9 +73,9 @@ const config = {
         respectPrefersColorScheme: true,
       },
       navbar: {
-        title: "My Site",
+        title: "Mani.dev",
         logo: {
-          alt: "My Site Logo",
+          alt: "Mani.dev Logo",
           src: "img/logo.svg",
         },
         items: [
@@ -98,7 +88,7 @@ const config = {
           },
           { to: "/blog", label: "Blog", position: "left" },
           {
-            href: "https://github.com/facebook/docusaurus",
+            href: "https://github.com/Maniarasan/mani.dev",
             label: "GitHub",
             position: "right",
           },
@@ -142,7 +132,7 @@ const config = {
               },
               {
                 label: "GitHub",
-                href: "https://github.com/facebook/docusaurus",
+                href: "https://github.com/Maniarasan/mani.dev",
               },
             ],
           },
@@ -155,5 +145,4 @@ const config = {
       },
     }),
 };
-
 export default config;


### PR DESCRIPTION
- Changed site title to 'Mani.dev' and tagline to 'Software Engineering Knowledge Base'
- Updated organizationName to 'Maniarasan' and projectName to 'mani.dev'
- Updated editUrl in docs and blog sections to point to the correct repo
- Updated navbar and footer GitHub links to point to https://github.com/Maniarasan/mani.dev
- Updated navbar title and logo alt text