### PR TITLE
Fix blog authors 2025

### DIFF
--- a/blog/2019-05-28-first-blog-post.md
+++ b/blog/2019-05-28-first-blog-post.md
@@ -1,7 +1,7 @@
 ---
 slug: first-blog-post
 title: First Blog Post
-authors: [slorber, yangshun]
+authors: [Maniarasan]
 tags: [hola, docusaurus]
 ---
 

--- a/blog/2019-05-29-long-blog-post.md
+++ b/blog/2019-05-29-long-blog-post.md
@@ -1,7 +1,7 @@
 ---
 slug: long-blog-post
 title: Long Blog Post
-authors: yangshun
+authors: Maniarasan
 tags: [hello, docusaurus]
 ---
 

--- a/blog/2021-08-01-mdx-blog-post.mdx
+++ b/blog/2021-08-01-mdx-blog-post.mdx
@@ -1,7 +1,7 @@
 ---
 slug: mdx-blog-post
 title: MDX Blog Post
-authors: [slorber]
+authors: [Maniarasan]
 tags: [docusaurus]
 ---
 

--- a/blog/2021-08-26-welcome/index.md
+++ b/blog/2021-08-26-welcome/index.md
@@ -1,7 +1,7 @@
 ---
 slug: welcome
 title: Welcome
-authors: [slorber, yangshun]
+authors: [Maniarasan]
 tags: [facebook, hello, docusaurus]
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes the Docusaurus build error caused by references to invalid authors ('slorber' and 'yangshun') in old blog posts. These authors were removed from authors.yml in PR #2, but the old blog posts were not updated accordingly.

## Changes

Updated the `authors` field in the following blog posts to use 'Maniarasan' instead of the invalid authors:

1. `blog/2019-05-28-first-blog-post.md` - Changed from `[slorber, yangshun]` to `[Maniarasan]`
2. `blog/2019-05-29-long-blog-post.md` - Changed from `yangshun` to `Maniarasan`
3. `blog/2021-08-01-mdx-blog-post.mdx` - Changed from `[slorber]` to `[Maniarasan]`
4. `blog/2021-08-26-welcome/index.md` - Changed from `[slorber, yangshun]` to `[Maniarasan]`

## Fixes

This PR resolves the build error:
```
Error: Blog author with key "slorber" not found in the authors map file.
Valid author keys are:
- Maniarasan
```

After these changes, all blog posts will reference only the valid author 'Maniarasan', and the Docusaurus build should succeed.