### PR TITLE
Fix docs navigation: Remove empty intro page and update references

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,35 +3,27 @@
 // (when paired with `@ts-check`).
 // There are various equivalent ways to declare your Docusaurus config.
 // See: https://docusaurus.io/docs/api/docusaurus-config
-
 import { themes as prismThemes } from "prism-react-renderer";
-
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Mani.dev",
   tagline: "Software Engineering Knowledge Base",
   favicon: "img/favicon.ico",
-
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
-
   // Set the production url of your site here
   url: "https://maniarasan.github.io/",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/mani.dev/",
-
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "Maniarasan", // Usually your GitHub org/user name.
   projectName: "mani.dev", // Usually your repo name.
-
   onBrokenLinks: "throw",
-
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
@@ -39,7 +31,6 @@ const config = {
     defaultLocale: "en",
     locales: ["en"],
   },
-
   presets: [
     [
       "classic",
@@ -73,7 +64,6 @@ const config = {
       }),
     ],
   ],
-
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -90,7 +80,7 @@ const config = {
         },
         items: [
           { to: "/", label: "Home", position: "left" },
-          { type: "doc", docId: "intro", position: "left", label: "Docs" },
+          { to: "/docs/ai", label: "Docs", position: "left" },
           { to: "/blog", label: "Blog", position: "left" },
           { to: "/about", label: "About Me", position: "left" },
           {
@@ -108,7 +98,7 @@ const config = {
             items: [
               {
                 label: "Documentation",
-                to: "/docs/intro",
+                to: "/docs/ai",
               },
               {
                 label: "Blog",
@@ -151,5 +141,4 @@ const config = {
       },
     }),
 };
-
 export default config;


### PR DESCRIPTION
## Summary

This PR addresses the issue where clicking "Docs" in the navigation led to an empty intro page. The intro page served no purpose and created a poor user experience.

## Changes Made

1. **Deleted `docs/intro.md`**: Removed the empty intro file that was serving no purpose
2. **Updated `docusaurus.config.js`**:
   - Changed navbar "Docs" link from `{ type: "doc", docId: "intro" }` to `{ to: "/docs/ai" }`
   - Changed footer "Documentation" link from `/docs/intro` to `/docs/ai`

## Decision Rationale

**Evaluated**: Whether the intro page was needed
- The intro.md file was completely empty with no content
- The sidebar auto-generated from docs folder structure already shows all categories (AI, JavaScript, Node.js)
- An empty landing page adds no value and creates confusion

**Result**: Removed the intro page entirely and redirect "Docs" to the first documentation category (/docs/ai)

## Impact

✅ **Before**: Clicking "Docs" → Empty intro page with just a title
✅ **After**: Clicking "Docs" → AI documentation category with actual content

This provides a better user experience by immediately showing relevant documentation instead of a blank page.